### PR TITLE
make package installable with new magento minor releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "OSL-3.0"
     ],
     "require": {
-        "magento/framework": "100.0.*"
+        "magento/framework": "^100.0.0"
     },
     "type": "magento2-language",
     "autoload": {


### PR DESCRIPTION
the language pack can currently not be installed with 2.1-rc01. This is because the minor version of the framework is also pushed, but the language pack still requires 100.0.  The '^' operator is designed for semantic versioning (which is used by the Magento Team) and should mostly take care, that your package is only installed in compatible magento instances (where Major Version = 100)