### PR TITLE
fix typo in html markup

### DIFF
--- a/de_DE.csv
+++ b/de_DE.csv
@@ -1434,7 +1434,7 @@ Clear Price,Preis entfernen
 Clear Shopping Cart,Warenkorb löschen
 "Click ""Save"" to apply the rates we found.","Klicken Sie auf ""Speichern"", um die Kurse anzuwenden."
 "Click <a href=""%1"">here</a> if nothing has happened","Klicken Sie <a href=""%1"">hier</a>, falls nicht geschieht"
-"Click <a href=""%1"">here</a> to continue shopping.","Klicken Sie <a href=""%1"" hier</a>, um den Einkauf fortzusetzen."
+"Click <a href=""%1"">here</a> to continue shopping.","Klicken Sie <a href=""%1"">hier</a>, um den Einkauf fortzusetzen."
 "Click <a href=""%1"">here</a> to see the review.","Klicken Sie <a href=""%1"">hier</a> um die Bewertung zu sehen"
 Click Details for more required fields.,Auf Details klicken für mehr erforderliche Felder
 Click for price,Für Preis klicken


### PR DESCRIPTION
fix typo in html markup for `continue shopping` on empty cart