### PR TITLE
Fixed translating tag id which was breaking german backend

### DIFF
--- a/de_DE.csv
+++ b/de_DE.csv
@@ -4679,7 +4679,7 @@ Order tracking,Bestellverfolgung
 Order Updated,Bestellung aktualisiert
 Order Valid Period (days),Gültigskeitsdauer von Bestellungen (Tage)
 Order View,Bestellübersicht
-order-header,Bestellungs-Kopfzeile
+order-header,order-header
 Ordered,Bestellt
 ordered,Bestellt
 Ordered amount of %1,Bestellte Menge von %1


### PR DESCRIPTION
Hi guys!

I re-set the translation of `order-header` to its English state because this is an id of html tag. When translated [javascript code](https://github.com/magento/magento2/blob/fb6faf5975fd7580eb407f089f8fbcacd5ee42f5/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js#L118) in `scripts.js` cannot find this element anymore and breaks some functionality in magento BE. This ended up localized by accident due to [a magento bug](https://github.com/magento/magento2/issues/5533), which has been fixed recently. The [fix](https://github.com/magento/magento2/commit/3e2ef715e9589f158b45d020dafb08d28c844238) only set `translate` attribute to `false` but did not remove the [string](https://github.com/magento/magento2/blob/develop/app/code/Magento/Sales/i18n/en_US.csv#L741) from the `.csv` file. I suspect therefore that we cannot simple remove it from the translation file. Rather we have to keep it but provide no translation.