### PR TITLE
Update de_DE.csv

### DIFF
--- a/de_DE.csv
+++ b/de_DE.csv
@@ -6735,7 +6735,7 @@ Reference for business rules,Referenz für Geschäftsregeln,module,FireGento_Mag
 Reference ID,Referenz-ID,,
 Reference ID:,Referenz-ID:,,
 Reference Information,Referenzinformationen,,
-Reference number,Eine Nummer referenzieren,,
+Reference number,Verwendungszweck,,
 Referred Customer Group,Referenzierte Kundengruppe,,
 Reflection Data,Reflexions-Daten,,
 Refresh,Aktualisieren,,


### PR DESCRIPTION
Die Übersetzung für "Reference number" ist mit "eine Nummer referenzieren" falsch. Da es bei Paypalplus benutzt wird, würde ich hier "Verwendungszweck" vorschlagen.