### PR TITLE
[BUGFIX] remove double dashes in translated string

### DIFF
--- a/de_DE.csv
+++ b/de_DE.csv
@@ -8946,7 +8946,7 @@ Transaction reversal by PayPal administrators.,Stornierung der Transaktion durch
 Transaction reversal due to fraud detected by PayPal administrators.,Stornierung der Transaktion aufgrund eines durch PayPal-Administratoren erkannten Betrugs.,,
 Transaction Type,Transaktionstyp,,
 Transaction was not placed.,Überweisung wurde nicht platziert.,,
-Transactional Emails,Transaktions--Mails,,
+Transactional Emails,Transaktions-Mails,,
 Transactions,Transaktionen,,
 Transfer Cart Line Items,Übertrage Artikel im Einkaufswagen,,
 Transfer Shipping Options,Übertrage Versandoptionen,,


### PR DESCRIPTION
This PR removes the double dashes in "Transaktions--Mails"