### PR TITLE
Fix invalid postcode translation

### DIFF
--- a/de_DE.csv
+++ b/de_DE.csv
@@ -209,7 +209,7 @@
  [deleted], [gelöscht],module,Magento_Backend
  [deleted], [gelöscht],module,Magento_Sales
  Copy, Kopie,module,Magento_Newsletter
- Example: ,Beispiel:,module,Magento_Checkout
+ Example: , Beispiel: ,module,Magento_Checkout
  for more information or , für weitere Informationen oder,module,Magento_Shipping
  in your cart.,im Warenkorb.,module,Amasty_Cart
  is not available. You still can process offline actions., ist nicht verfügbar. Sie können weiterhin Offline-Aktionen ausführen.,module,Magento_Payment


### PR DESCRIPTION
The original has a space before and after the word. The translation does not have these, which leads to issues in some layouts.