### PR TITLE
change: replace bad sounding word

### DIFF
--- a/de_DE.csv
+++ b/de_DE.csv
@@ -13415,7 +13415,7 @@ We will send you a notification once your items are ready for pickup.,"Wir sende
 We'll ask for your payment details before you place an order.,"Wir werden Sie nach Ihren Zahlungsdetails fragen, bevor Sie Ihre Bestellung aufgeben.",,
 We'll authorize the amount of %1 as soon as the payment gateway approves it.,"Wir werden die Menge von %1 genehmigen, sobald das Zahlungs-Gateway dies genehmigt.",,
 We'll email you a link to reset your password.,"Wir haben Ihnen eine Link geschickt, um Ihr Password neu zu setzen.",,
-We'll email you an order confirmation with details and tracking info.,Wir schicken Ihnen per E-Mail eine Bestellbestätigung mit Details und Informationen zur Sendeverfolgung.,,
+We'll email you an order confirmation with details and tracking info.,Wir schicken Ihnen per E-Mail eine Bestellbestätigung mit Details und Informationen zur Sendungsverfolgung.,,
 We'll send your order confirmation here.,Wir werden Ihre Bestellbestätigung an diese E-Mail senden.,,
 We'll use the default description above if you leave this empty.,"Obige Standardbeschreibung wird verwendet, wenn Sie diese leer lassen.",,
 We'll use the default error above if you leave this empty.,"Wir werden den obigen Standardfehler nutzen, wenn Sie dies leer lassen.",,


### PR DESCRIPTION
Replaces "Sendeverfolung" with "Sendungsverfolgung" because it's better sounding.

Closes #179 